### PR TITLE
Document bind address fix

### DIFF
--- a/3.4.10/docker-entrypoint.sh
+++ b/3.4.10/docker-entrypoint.sh
@@ -31,9 +31,8 @@ if [ ! -f "$ZOO_DATA_DIR/myid" ]; then
         ZOO_MY_ID=$(($(hostname | sed s/.*-//) + 1))
         echo "Guessed server id: $ZOO_MY_ID"
         # Tries to bind to it's own server entry, which won't work with names ("Exception while listening java.net.SocketException: Unresolved address")
-        cp $ZOO_CONF_DIR/zoo.cfg $ZOO_CONF_DIR/zoo.cfg.org
+        sed -n "s/server\.$ZOO_MY_ID\=[a-z0-9.-]*/server.$ZOO_MY_ID=0.0.0.0/p" "$ZOO_CONF_DIR/zoo.cfg"
         sed -i "s/server\.$ZOO_MY_ID\=[a-z0-9.-]*/server.$ZOO_MY_ID=0.0.0.0/" "$ZOO_CONF_DIR/zoo.cfg"
-        diff -s -u $ZOO_CONF_DIR/zoo.cfg.org $ZOO_CONF_DIR/zoo.cfg || echo "Fixed bind address for this instance"
     fi
     echo "${ZOO_MY_ID:-1}" > "$ZOO_DATA_DIR/myid"
 fi


### PR DESCRIPTION
Includes bd77f1c 30a69e6 9f94dbc but those are already in the latest build https://github.com/solsson/zookeeper-docker/releases/tag/docker.0ad93c98d5165b4eb747c4b0dd04a7a448a5c4b4cbcaa4bffc15018b76b81bb5.

Issues with the current entrypoint script:
 * You might not be aware of it
 * You can't select the bind address
 * Writes a temp file for the diff, which might fail depending on volumes
 * Runs even if zoo.cfg existed on start. Should only run when it's generated.